### PR TITLE
fix: step ref name for grafana key

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -79,7 +79,7 @@ jobs:
         id: tf-apply
         uses: WalletConnect/actions/terraform/apply/@1.0.0
         env:
-          GRAFANA_AUTH: ${{ steps.get-grafana-key.outputs.key }}
+          GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.get-grafana-details.outputs.endpoint }}
           # TF_VAR_image_version: ${{ needs.get-version.outputs.version }}
         with:


### PR DESCRIPTION
# Description

Fix the step reference name when running Terraform apply in CI

## How Has This Been Tested?

Not tested (CI only)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update