### PR TITLE
fix: install `protoc` before `cocogitto` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: "Cocogitto release"
         id: release
         uses: cocogitto/cocogitto-action@v3
@@ -54,9 +57,6 @@ jobs:
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
 
       - name: "Generate Changelog"
         run: cog changelog --at ${{ steps.release.outputs.version }} -t full_hash > GITHUB_CHANGELOG.md


### PR DESCRIPTION
# Description

Install `protoc` before `cocogitto` in release workflow

## How Has This Been Tested?

Not tested (CI)

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update