### PR TITLE
fix: remove version bump commit from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,13 @@ jobs:
           sed "s/^version = \".*\"\$/version = \"$version\"/" ./Cargo.toml > /tmp/cargo.toml
           mv /tmp/cargo.toml ./Cargo.toml
 
-      - name: "Commit version bump"
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore: Bump version for release"
-          file_pattern: "Cargo.toml Cargo.lock"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+#      - name: "Commit version bump"
+#        uses: stefanzweifel/git-auto-commit-action@v4
+#        with:
+#          commit_message: "chore: Bump version for release"
+#          file_pattern: "Cargo.toml Cargo.lock"
+#          commit_user_name: "github-actions[bot]"
+#          commit_user_email: "github-actions[bot]@users.noreply.github.com"
 
       - name: "Install Rust toolchain (stable)"
         uses: actions-rs/toolchain@v1
@@ -95,7 +95,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registryfix/ci
         uses: docker/login-action@v2
         with:
           registry: ghcr.io


### PR DESCRIPTION
# Description

Remove version commit from release workflow

## How Has This Been Tested?

Not tested (CI)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update