### PR TITLE
fix: remove requirement for server signature

### DIFF
--- a/src/handlers/save_message.rs
+++ b/src/handlers/save_message.rs
@@ -27,7 +27,8 @@ pub struct HistoryPayload {
 
 pub async fn handler(
     StateExtractor(state): StateExtractor<Arc<AppState>>,
-    RequireValidSignature(Json(payload)): RequireValidSignature<Json<HistoryPayload>>,
+    // RequireValidSignature(Json(payload)): RequireValidSignature<Json<HistoryPayload>>,
+    Json(body): Json<HistoryPayload>,
 ) -> error::Result<Response> {
     debug!("Received `save_message` query: {:?}", payload);
 


### PR DESCRIPTION
# Description

Accept unsigned messages from `relay`
