### PR TITLE
fix: remove authentication for get queries

### DIFF
--- a/src/relay/signature.rs
+++ b/src/relay/signature.rs
@@ -26,7 +26,7 @@ impl<S, B, T> FromRequest<S, B> for RequireValidSignature<T>
 where
     // these bounds are required by
     // `async_trait`
-    B: Send + 'static + body::HttpBody + From<hyper::body::Bytes>,
+    B: Send + 'static + body::HttpBody + From<body::Bytes>,
     B::Data: Send,
     S: Send + Sync + State,
     T: FromRequest<S, B>,
@@ -82,7 +82,6 @@ where
             (Some(_), None) => Err(MissingTimestampHeader),
             (None, Some(_)) => Err(MissingSignatureHeader),
             (None, None) => Err(MissingAllSignatureHeader),
-            _ => Err(MissingAllSignatureHeader),
         }
     }
 }

--- a/src/store/messages.rs
+++ b/src/store/messages.rs
@@ -2,7 +2,7 @@ use {
     super::StoreError,
     async_trait::async_trait,
     serde::{Deserialize, Serialize},
-    std::sync::Arc,
+    std::{fmt::Debug, sync::Arc},
     wither::{
         bson::{self, doc, oid::ObjectId},
         Model,
@@ -14,7 +14,7 @@ use {
     collection_name = "Messages",
     index(keys = r#"doc!{"ts": 1}"#),
     index(keys = r#"doc!{"ts": -1}"#),
-    index(keys = r#"doc!{"client_id": 1, "topic": 1}"#),
+    index(keys = r#"doc!{"topic": 1}"#),
     index(
         keys = r#"doc!{"client_id": 1, "topic": 1, "message_id": 1}"#,
         options = r#"doc!{"unique": true}"#
@@ -46,7 +46,7 @@ pub struct StoreMessages {
 }
 
 #[async_trait]
-pub trait MessagesStore: 'static + std::fmt::Debug + Send + Sync {
+pub trait MessagesStore: 'static + Send + Sync {
     async fn upsert_message(
         &self,
         method: &str,
@@ -57,14 +57,12 @@ pub trait MessagesStore: 'static + std::fmt::Debug + Send + Sync {
     ) -> Result<(), StoreError>;
     async fn get_messages_after(
         &self,
-        client_id: &str,
         topic: &str,
         origin: Option<&str>,
         message_count: usize,
     ) -> Result<StoreMessages, StoreError>;
     async fn get_messages_before(
         &self,
-        client_id: &str,
         topic: &str,
         origin: Option<&str>,
         message_count: usize,

--- a/src/store/mongo/mod.rs
+++ b/src/store/mongo/mod.rs
@@ -21,7 +21,7 @@ use {
     },
 };
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MongoStore {
     db: Database,
 }
@@ -64,7 +64,6 @@ impl MongoStore {
 
     async fn get_messages(
         &self,
-        client_id: &str,
         topic: &str,
         origin: Option<&str>,
         message_count: usize,
@@ -73,13 +72,11 @@ impl MongoStore {
     ) -> Result<StoreMessages, StoreError> {
         let filter: Result<Document, StoreError> = match origin {
             None => Ok(doc! {
-                "client_id": &client_id,
                 "topic": &topic,
             }),
             Some(origin) => {
                 let ts = self.get_message_timestamp(topic, origin).await?;
                 Ok(doc! {
-                    "client_id": &client_id,
                     "topic": &topic,
                     "ts": { comparator: ts }
                 })
@@ -147,23 +144,21 @@ impl MessagesStore for MongoStore {
 
     async fn get_messages_after(
         &self,
-        client_id: &str,
         topic: &str,
         origin: Option<&str>,
         message_count: usize,
     ) -> Result<StoreMessages, StoreError> {
-        self.get_messages(client_id, topic, origin, message_count, "$gte", 1)
+        self.get_messages(topic, origin, message_count, "$gte", 1)
             .await
     }
 
     async fn get_messages_before(
         &self,
-        client_id: &str,
         topic: &str,
         origin: Option<&str>,
         message_count: usize,
     ) -> Result<StoreMessages, StoreError> {
-        self.get_messages(client_id, topic, origin, message_count, "$lte", -1)
+        self.get_messages(topic, origin, message_count, "$lte", -1)
             .await
     }
 }

--- a/src/store/registrations.rs
+++ b/src/store/registrations.rs
@@ -27,7 +27,7 @@ pub struct Registration {
 }
 
 #[async_trait]
-pub trait RegistrationStore: 'static + std::fmt::Debug + Send + Sync {
+pub trait RegistrationStore: 'static + Send + Sync {
     async fn upsert_registration(
         &self,
         client_id: &str,

--- a/tests/storage/messages.rs
+++ b/tests/storage/messages.rs
@@ -21,7 +21,7 @@ async fn test_after_no_origin(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_after(TEST_CLIENT_ID, topic, None, TEST_QUERY_SIZE)
+        .get_messages_after(topic, None, TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -58,12 +58,7 @@ async fn test_after_origin(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_after(
-            TEST_CLIENT_ID,
-            topic,
-            Some(&origin.to_string()),
-            TEST_QUERY_SIZE,
-        )
+        .get_messages_after(topic, Some(&origin.to_string()), TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -104,12 +99,7 @@ async fn test_after_origin_overflow(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_after(
-            TEST_CLIENT_ID,
-            topic,
-            Some(&origin.to_string()),
-            TEST_QUERY_SIZE,
-        )
+        .get_messages_after(topic, Some(&origin.to_string()), TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -140,7 +130,7 @@ async fn test_before_no_origin(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_before(TEST_CLIENT_ID, topic, None, TEST_QUERY_SIZE)
+        .get_messages_before(topic, None, TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -177,12 +167,7 @@ async fn test_before_origin(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_before(
-            TEST_CLIENT_ID,
-            topic,
-            Some(&origin.to_string()),
-            TEST_QUERY_SIZE,
-        )
+        .get_messages_before(topic, Some(&origin.to_string()), TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -223,12 +208,7 @@ async fn test_before_origin_overflow(ctx: &StoreContext) {
     let result = ctx
         .storage
         .store
-        .get_messages_before(
-            TEST_CLIENT_ID,
-            topic,
-            Some(&origin.to_string()),
-            TEST_QUERY_SIZE,
-        )
+        .get_messages_before(topic, Some(&origin.to_string()), TEST_QUERY_SIZE)
         .await
         .unwrap();
 
@@ -267,7 +247,7 @@ async fn test_multi_topic(ctx: &StoreContext) {
         let result = ctx
             .storage
             .store
-            .get_messages_after(TEST_CLIENT_ID, topic.as_str(), None, QUERY_SIZE)
+            .get_messages_after(topic.as_str(), None, QUERY_SIZE)
             .await
             .unwrap();
 
@@ -309,12 +289,10 @@ async fn test_multi_clients(ctx: &StoreContext) {
     }
 
     for t in 0..NUM_CLIENTS {
-        let client_id = format!("{}-{}", TEST_CLIENT_ID, t + 1);
-
         let result = ctx
             .storage
             .store
-            .get_messages_after(client_id.as_str(), topic, None, QUERY_SIZE)
+            .get_messages_after(topic, None, QUERY_SIZE)
             .await
             .unwrap();
 

--- a/tests/storage/mocks/messages.rs
+++ b/tests/storage/mocks/messages.rs
@@ -77,18 +77,10 @@ impl MessagesStore for MockMessageStore {
 
     async fn get_messages_after(
         &self,
-        client_id: &str,
         _topic: &str,
         _origin: Option<&str>,
         _message_count: usize,
     ) -> Result<StoreMessages, StoreError> {
-        if self.client_id.is_some() && self.client_id != Some(client_id.to_string()) {
-            return Err(StoreError::NotFound(
-                "messages".to_string(),
-                client_id.to_string(),
-            ));
-        }
-
         Ok(StoreMessages {
             messages: self.test_get_messages(),
             next_id: Some(Arc::from("after")),
@@ -97,18 +89,10 @@ impl MessagesStore for MockMessageStore {
 
     async fn get_messages_before(
         &self,
-        client_id: &str,
         _topic: &str,
         _origin: Option<&str>,
         _message_count: usize,
     ) -> Result<StoreMessages, StoreError> {
-        if self.client_id.is_some() && self.client_id != Some(client_id.to_string()) {
-            return Err(StoreError::NotFound(
-                "messages".to_string(),
-                client_id.to_string(),
-            ));
-        }
-
         Ok(StoreMessages {
             messages: self.test_get_messages(),
             next_id: Some(Arc::from("before")),


### PR DESCRIPTION
# Description

Remove `jwt` authentication for "get messages" requests to enable clients to retrieve the whole history for a topic.

## How Has This Been Tested?

Unit tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update