### PR TITLE
chore: break method API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/handlers/get_messages.rs
+++ b/src/handlers/get_messages.rs
@@ -4,7 +4,7 @@ use {
         increment_counter,
         increment_counter_with,
         state::AppState,
-        store::messages::{Message, StoreMessages},
+        store::messages::{Message, StoreMessages, MAGIC_SKIP_SERIALIZING_METHOD},
     },
     axum::{
         extract::{Query, State},
@@ -100,6 +100,13 @@ pub async fn handler(
 
     increment_counter!(state.metrics, get_queries);
     increment_counter_with!(state.metrics, served_items, messages.len() as u64);
+
+    // Prematurely make breaking change of removing method
+    // https://walletconnect.slack.com/archives/C04CKNV4GN8/p1688127376863359
+    let mut messages = messages;
+    for message in messages.iter_mut() {
+        message.method = MAGIC_SKIP_SERIALIZING_METHOD.to_owned().into();
+    }
 
     let response = GetMessagesResponse {
         topic: query.topic.clone(),

--- a/src/store/messages.rs
+++ b/src/store/messages.rs
@@ -28,6 +28,7 @@ pub struct Message {
     #[serde(rename = "ts")]
     pub timestamp: bson::DateTime,
     /// The messages method (`publish`/`subscription`).
+    #[serde(skip_serializing_if = "is_magic_skip_serializing_method")]
     pub method: Arc<str>,
     /// The message's client ID.
     pub client_id: Arc<str>,
@@ -37,6 +38,15 @@ pub struct Message {
     pub message_id: Arc<str>,
     /// The actual message.
     pub message: Arc<str>,
+}
+
+// Because `#[derive(Modal)]` requires `#[derive(Serialize)]` I assume
+// `#[serde(skip_serializing)]` skips serializing when *writing* to MongoDB, not
+// just rendering as JSON. So using magic value instead so we can rollback if
+// necessary and we don't loose any data.
+pub const MAGIC_SKIP_SERIALIZING_METHOD: &str = "956ab70e-bbb0-4c23-af39-95a252275bfe";
+fn is_magic_skip_serializing_method(method: &str) -> bool {
+    method == MAGIC_SKIP_SERIALIZING_METHOD
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/store/messages.rs
+++ b/src/store/messages.rs
@@ -28,7 +28,10 @@ pub struct Message {
     #[serde(rename = "ts")]
     pub timestamp: bson::DateTime,
     /// The messages method (`publish`/`subscription`).
-    #[serde(skip_serializing_if = "is_magic_skip_serializing_method")]
+    #[serde(
+        skip_serializing_if = "is_magic_skip_serializing_method",
+        default = "default_magic_skip_serializing_method"
+    )]
     pub method: Arc<str>,
     /// The message's client ID.
     pub client_id: Arc<str>,
@@ -47,6 +50,10 @@ pub struct Message {
 pub const MAGIC_SKIP_SERIALIZING_METHOD: &str = "956ab70e-bbb0-4c23-af39-95a252275bfe";
 fn is_magic_skip_serializing_method(method: &str) -> bool {
     method == MAGIC_SKIP_SERIALIZING_METHOD
+}
+
+fn default_magic_skip_serializing_method() -> Arc<str> {
+    MAGIC_SKIP_SERIALIZING_METHOD.to_owned().into()
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
# Description

Prematurely break method API as it is not needed by any SDKs: https://walletconnect.slack.com/archives/C04CKNV4GN8/p1688127376863359

This is in preparation for webhooks 2.0 where `method` is no longer sent: https://walletconnect.slack.com/archives/C05ABTQSPFY/p1688072990077729

Doing now in order to avoid surprises later. And we can easily roll this back with minimal damage if we realize we needed it.

Also updated `proc-macro2` just like I did over [here](https://github.com/WalletConnect/gilgamesh/pull/45#issuecomment-1613757690).

Resolves #48

## How Has This Been Tested?

Not tested

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update