### PR TITLE
fix: upscale the ECS cluster to meet demand

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,9 +79,9 @@ module "ecs" {
   prometheus_endpoint             = aws_prometheus_workspace.prometheus.prometheus_endpoint
   image                           = "${data.aws_ecr_repository.repository.repository_url}:${local.version}"
   acm_certificate_arn             = module.dns.certificate_arn
-  cpu                             = 512
+  cpu                             = 1024
   route53-fqdn                    = local.fqdn
-  memory                          = 1024
+  memory                          = 2048
   private_subnets                 = module.vpc.private_subnets
   public_subnets                  = module.vpc.public_subnets
   log_region                      = var.region


### PR DESCRIPTION
# Description

Upscale the ECS cluster to meet new demand

![image](https://github.com/WalletConnect/gilgamesh/assets/160293/d29dea7f-29d7-4ae4-b554-5472b5039a77)

## How Has This Been Tested?

not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update