### PR TITLE
fix: add CORS configuration to enable queries from browsers.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,5 @@ MONGO_ADDRESS=mongodb://admin:admin@localhost:27017/gilgamesh?authSource=admin
 # HTTP clients e.g. curl, insomnia, postman, etc
 VALIDATE_SIGNATURES=false
 
-# CORS
-CORS_ALLOWED_ORIGINS=*
-
 # Telemetry
 TELEMETRY_PROMETHEUS_PORT=3001

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ const DEFAULT_PORT_NUMBER: u16 = 3001;
 const DEFAULT_LOG_LEVEL: &str = "WARN";
 const DEFAULT_RELAY_URL: &str = "https://relay.walletconnect.com";
 const DEFAULT_VALIDATE_SIGNATURES: bool = true;
-const DEFAULT_CORS_ALLOWED_ORIGINS: &[&str] = &["*"];
 
 /// The server configuration.
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -26,9 +25,6 @@ pub struct Configuration {
     /// An internal flag to disable logging, cannot be defined by user.
     #[serde(default = "default_is_test", skip)]
     pub is_test: bool,
-    // CORS
-    #[serde(default = "default_cors_allowed_origins")]
-    pub cors_allowed_origins: Vec<String>,
 
     pub otel_exporter_otlp_endpoint: Option<String>,
     pub telemetry_prometheus_port: Option<u16>,
@@ -63,13 +59,6 @@ fn default_validate_signatures() -> bool {
 
 fn default_is_test() -> bool {
     false
-}
-
-fn default_cors_allowed_origins() -> Vec<String> {
-    DEFAULT_CORS_ALLOWED_ORIGINS
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>()
 }
 
 /// Create a new configuration from the environment variables.

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -64,7 +64,6 @@ resource "aws_ecs_task_definition" "app_task_definition" {
         { name = "PUBLIC_URL", value = "http://localhost:8080" }, // TODO: Change this to the actual public URL
         { name = "LOG_LEVEL", value = var.log_level },
         { name = "MONGO_ADDRESS", value = var.docdb-connection_url },
-        { name = "CORS_ALLOWED_ORIGINS", value = "*" },
         { name = "TELEMETRY_PROMETHEUS_PORT", value = "8081" }
       ],
       dependsOn = [

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -55,7 +55,6 @@ impl Gilgamesh {
                     validate_signatures: false,
                     mongo_address,
                     is_test: true,
-                    cors_allowed_origins: vec!["*".to_string()],
                     otel_exporter_otlp_endpoint: None,
                     telemetry_prometheus_port: Some(get_random_port()),
                 };

--- a/tests/context/store.rs
+++ b/tests/context/store.rs
@@ -23,7 +23,6 @@ impl PersistentStorage {
             validate_signatures: false,
             mongo_address,
             is_test: true,
-            cors_allowed_origins: vec!["*".to_string()],
             otel_exporter_otlp_endpoint: None,
             telemetry_prometheus_port: Some(get_random_port()),
         };


### PR DESCRIPTION
# Description

Simplifies the CORS configuration since there are no cases yet where we need restrictions and the dynamic way seems broken.

Resolves #57 

## How Has This Been Tested?

`cargo test`

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update