### PR TITLE
feat: spans with information

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -60,7 +60,7 @@ impl AuthBearer {
         Self(contents.to_string())
     }
 
-    fn decode_request_parts(req: &mut Parts) -> Result<Self, Rejection> {
+    fn decode_request_parts(req: &Parts) -> Result<Self, Rejection> {
         // Get authorization header
         let authorization = req
             .headers
@@ -73,7 +73,7 @@ impl AuthBearer {
         let split = authorization.split_once(' ');
         match split {
             // Found proper bearer
-            Some((name, contents)) if name == "Bearer" => Ok(Self::from_header(contents)),
+            Some(("Bearer", contents)) => Ok(Self::from_header(contents)),
             // Found empty bearer
             _ if authorization == "Bearer" => Ok(Self::from_header("")),
             // Found nothing

--- a/src/handlers/register.rs
+++ b/src/handlers/register.rs
@@ -70,6 +70,10 @@ async fn overwrite_registration(
     tags: HashSet<Arc<str>>,
     relay_url: Arc<str>,
 ) -> error::Result<Response> {
+    info!(
+        "DBG:{}:overwrite_registration: upsert registration",
+        client_id
+    );
     state
         .registration_store
         .upsert_registration(
@@ -79,6 +83,10 @@ async fn overwrite_registration(
         )
         .await?;
 
+    info!(
+        "DBG:{}:overwrite_registration: cache registration",
+        client_id
+    );
     state
         .registration_cache
         .insert(client_id.into_value(), CachedRegistration {
@@ -100,15 +108,27 @@ async fn update_registration(
     let append_tags = append_tags.unwrap_or_default();
     let remove_tags = remove_tags.unwrap_or_default();
 
+    info!(
+        "DBG:{}:update_registration: process intersection of <append_tags> and <remove_tags>...",
+        client_id
+    );
     if remove_tags.intersection(&append_tags).count() > 0 {
         return Err(Error::InvalidUpdateRequest);
     }
 
+    info!(
+        "DBG:{}:update_registration: get current registration",
+        client_id
+    );
     let registration = state
         .registration_store
         .get_registration(client_id.as_ref())
         .await?;
 
+    info!(
+        "DBG:{}:update_registration: get current registration",
+        client_id
+    );
     let tags = registration
         .tags
         .into_iter()
@@ -120,5 +140,6 @@ async fn update_registration(
         .cloned()
         .collect();
 
+    info!("DBG:{}: overwrite registration", client_id);
     overwrite_registration(state, client_id, tags, relay_url).await
 }

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -42,7 +42,6 @@ impl Gilgamesh {
 
         std::thread::spawn(move || {
             rt.block_on(async move {
-                let public_port = public_port;
                 let mongo_address = env::var("MONGO_ADDRESS").unwrap_or(
                     "mongodb://admin:admin@mongo:27017/gilgamesh?authSource=admin".into(),
                 );


### PR DESCRIPTION
# Description

Currently errors have no logs. We also have no HTTP metrics informing which route fails. This is an attempt to get HTTP path/method to inform which routes are failing.

<img width="1341" alt="Screenshot 2023-08-31 at 10 21 18 PM" src="https://github.com/WalletConnect/gilgamesh/assets/966091/d38c3b3f-9309-437f-bb39-057956936ea0">


## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update