### PR TITLE
fix: return 4xx instead of 5xx on invalid JWT

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -102,6 +102,12 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         error!("responding with error ({:?})", self);
         match self {
+            Error::JwtError(e) => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
+                ResponseError {
+                    name: "jwt".to_string(),
+                    message: e.to_string(),
+                }
+            ], vec![]),
             Error::Database(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "mongodb".to_string(),

--- a/src/handlers/register.rs
+++ b/src/handlers/register.rs
@@ -70,10 +70,6 @@ async fn overwrite_registration(
     tags: HashSet<Arc<str>>,
     relay_url: Arc<str>,
 ) -> error::Result<Response> {
-    info!(
-        "DBG:{}:overwrite_registration: upsert registration",
-        client_id
-    );
     state
         .registration_store
         .upsert_registration(
@@ -83,10 +79,6 @@ async fn overwrite_registration(
         )
         .await?;
 
-    info!(
-        "DBG:{}:overwrite_registration: cache registration",
-        client_id
-    );
     state
         .registration_cache
         .insert(client_id.into_value(), CachedRegistration {
@@ -108,27 +100,15 @@ async fn update_registration(
     let append_tags = append_tags.unwrap_or_default();
     let remove_tags = remove_tags.unwrap_or_default();
 
-    info!(
-        "DBG:{}:update_registration: process intersection of <append_tags> and <remove_tags>...",
-        client_id
-    );
     if remove_tags.intersection(&append_tags).count() > 0 {
         return Err(Error::InvalidUpdateRequest);
     }
 
-    info!(
-        "DBG:{}:update_registration: get current registration",
-        client_id
-    );
     let registration = state
         .registration_store
         .get_registration(client_id.as_ref())
         .await?;
 
-    info!(
-        "DBG:{}:update_registration: get current registration",
-        client_id
-    );
     let tags = registration
         .tags
         .into_iter()
@@ -140,6 +120,5 @@ async fn update_registration(
         .cloned()
         .collect();
 
-    info!("DBG:{}: overwrite registration", client_id);
     overwrite_registration(state, client_id, tags, relay_url).await
 }


### PR DESCRIPTION
# Description

Return a client error instead of a server one when an authorized request sends an invalid JWT.

## How Has This Been Tested?

Added tests for this.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update